### PR TITLE
Fixes the problem with the escaping "save" button

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/gridTabAbstract.js
@@ -245,6 +245,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
         });
         var title = append ? t("batch_append_to") + " " + fieldInfo.text : t("batch_edit_field") + " " + fieldInfo.text;
         this.batchWin = new Ext.Window({
+            autoScroll: true,
             modal: false,
             title: title,
             items: [formPanel],


### PR DESCRIPTION
When performing mass actions on the grid there is a problem with the "save" button when adding many elements, eg to a multihref.

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  
http://oi68.tinypic.com/2lxilqd.jpg
